### PR TITLE
[FEAT] : [FE] 장바구니 담기 및 주문 생성 기능 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,29 +1,21 @@
 import Layout from "./components/Layout";
 import { Routes, Route } from "react-router-dom";
-
-import { ProductProvider } from "./context/ProductContext";
-
 import Signup from "./pages/Signup";
 import Main from "./pages/Main";
+import Cart from "./pages/Cart";
 
 function App() {
   return (
     <>
       <Layout>
         <Routes>
-          <Route
-            path="/"
-            element={
-              <ProductProvider>
-                <Main />
-              </ProductProvider>
-            }
-          />
+          <Route path="/" element={<Main />} />
           <Route path="/login" element={<div>로그인 페이지 컴포넌트</div>} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/mypage" element={<div>마이페이지 컴포넌트</div>} />
           <Route path="/admin" element={<div>상품 등록 컴포넌트</div>} />
           <Route path="/logout" element={<div>로그아웃 컴포넌트</div>} />
+          <Route path="/cart" element={<Cart />} />
         </Routes>
       </Layout>
     </>

--- a/frontend/src/components/CartPage.jsx
+++ b/frontend/src/components/CartPage.jsx
@@ -1,0 +1,86 @@
+import { useCartContext } from "../context/CartContext";
+
+export default function CartPage() {
+  const { cart, dispatch } = useCartContext();
+
+  const removeFromCart = (itemId) => {
+    dispatch({ type: "REMOVE_ITEM", payload: itemId });
+  };
+
+  const clearCart = () => {
+    dispatch({ type: "CLEAR_CART" });
+  };
+
+  const increaseQuantity = (itemId) => {
+    dispatch({ type: "INCREASE_ITEM", payload: itemId });
+  };
+
+  const decreaseQuantity = (itemId) => {
+    dispatch({ type: "DECREASE_ITEM", payload: itemId });
+  };
+
+  return (
+    <section className="bg-light border-b border-gray-500 container mx-auto mt-4 mb-2">
+      <ul role="list" className="divide-y divide-gray-100">
+        {cart.length === 0 ? (
+          <li className="py-5 text-center text-gray-500">
+            장바구니에 아이템이 없습니다.
+          </li>
+        ) : (
+          cart.map((item) => (
+            <li key={item.id} className="flex justify-between gap-x-6 py-5">
+              <div className="flex min-w-0 gap-x-4">
+                <img
+                  alt={item.name}
+                  src="https://i.imgur.com/HKOFQYa.jpeg"
+                  className="w-12 h-12 flex-none rounded-full bg-gray-50"
+                />
+                <div className="min-w-0 flex-auto">
+                  <p className="text-sm font-semibold text-gray-900">
+                    {item.name}
+                  </p>
+                  <p className="mt-1 text-xs text-gray-500">{item.price}원</p>
+                </div>
+              </div>
+              <div className="hidden shrink-0 sm:flex sm:flex-col sm:items-end">
+                <div className="flex items-center gap-x-2 mb-1">
+                  <button
+                    className="px-2 py-1 text-xs text-white bg-gray-500 rounded"
+                    onClick={() => decreaseQuantity(item.id)}
+                  >
+                    -
+                  </button>
+                  <span className="text-sm text-gray-900">{item.count}</span>
+                  <button
+                    className="px-2 py-1 text-xs text-white bg-gray-500 rounded"
+                    onClick={() => increaseQuantity(item.id)}
+                  >
+                    +
+                  </button>
+                </div>
+                <p className="text-sm text-gray-900">총 {item.totalprice}원</p>
+                <button
+                  className="mt-1 text-xs text-red-500"
+                  onClick={() => removeFromCart(item.id)}
+                >
+                  제거
+                </button>
+              </div>
+            </li>
+          ))
+        )}
+      </ul>
+
+      <div className="mt-4 mb-4 flex justify-end">
+        {cart.length > 0 && (
+          <button
+            className="py-2 px-4 bg-red-500 text-white rounded-md"
+            onClick={clearCart}
+          >
+            장바구니 비우기
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/CartPayment.jsx
+++ b/frontend/src/components/CartPayment.jsx
@@ -1,0 +1,89 @@
+import { useNavigate } from "react-router-dom";
+import { useCartContext } from "../context/CartContext";
+import useApi from "../hooks/useApi";
+import { useState } from "react";
+import OkCancelModal from "./OkCancelModal";
+
+const CartPayment = () => {
+  const { cart, dispatch } = useCartContext();
+  const navigate = useNavigate();
+  const totalItems = cart.reduce((acc, item) => acc + item.count, 0);
+  const totalAmount = cart.reduce((acc, item) => acc + item.totalprice, 0);
+  const formattedAmount = new Intl.NumberFormat().format(totalAmount);
+  const { request } = useApi();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [confirmMessage, setConfirmMessage] = useState("");
+
+  const handleMakeOrder = async (e) => {
+    e.preventDefault();
+
+    if (totalAmount === 0) {
+      alert("상품을 먼저 장바구니에 담아주세요!");
+      navigate("/");
+      return;
+    }
+
+    setConfirmMessage(`총금액은 ${totalAmount}원 입니다. 주문하시겠습니까?`);
+    setIsModalOpen(true);
+  };
+
+  const handleConfirmOrder = async () => {
+    const productData = {
+      product_info: cart.map((item) => ({
+        product_id: item.id,
+        amount: item.count,
+      })),
+    };
+
+    try {
+      const response = await request("/orders", "POST", productData);
+      alert(response.message);
+      navigate("/mypage");
+    } catch (err) {
+      alert(err);
+    }
+
+    dispatch({ type: "CLEAR_CART" });
+    setIsModalOpen(false);
+  };
+
+  const handleCancelOrder = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <section className="bg-light border-b border-gray-500 container mx-auto mt-4 mb-2">
+      <h2 className="text-2xl font-semibold text-gray-900 mb-6">결제 정보</h2>
+
+      <div className="mb-4">
+        <p className="text-lg text-gray-800">
+          전체 주문 수량:{" "}
+          <span className="font-bold text-blue-600">{totalItems}개</span>
+        </p>
+        <p className="text-lg text-gray-800">
+          총 결제 금액:{" "}
+          <span className="font-bold text-red-600">{formattedAmount}원</span>
+        </p>
+      </div>
+
+      <div className="mt-6 mb-4">
+        <button
+          className="py-3 px-6 bg-green-500 text-white rounded-lg hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-opacity-50"
+          onClick={handleMakeOrder}
+        >
+          주문하기
+        </button>
+      </div>
+
+      {/* OkCancelModal */}
+      <OkCancelModal
+        isOpen={isModalOpen}
+        message={confirmMessage}
+        onConfirm={handleConfirmOrder}
+        onCancel={handleCancelOrder}
+      />
+    </section>
+  );
+};
+
+export default CartPayment;

--- a/frontend/src/components/Error.jsx
+++ b/frontend/src/components/Error.jsx
@@ -10,7 +10,10 @@ const Error = ({ errorMessage }) => (
 );
 
 Error.propTypes = {
-  errorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.null]),
+  errorMessage: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf([null]),
+  ]),
 };
 
 export default Error;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -52,6 +52,14 @@ const Navbar = () => {
               상품 등록
             </Link>
           </li>
+          <li>
+            <Link
+              to="/cart"
+              className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
+            >
+              장바구니
+            </Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/frontend/src/components/OkCancelModal.jsx
+++ b/frontend/src/components/OkCancelModal.jsx
@@ -1,0 +1,45 @@
+import PropTypes from "prop-types";
+
+const OkCancelModal = ({
+  isOpen,
+  message,
+  onConfirm,
+  onCancel,
+  okButtonMessage = "확인",
+  cancelButtonMessage = "취소",
+}) => {
+  if (!isOpen) return null; // 모달이 열려있지 않으면 아무 것도 렌더링하지 않음
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-white p-6 rounded-lg shadow-lg">
+        <p>{message}</p>
+        <div className="mt-4">
+          <button
+            className="py-2 px-4 bg-blue-500 text-white rounded mr-2"
+            onClick={onConfirm}
+          >
+            {okButtonMessage}
+          </button>
+          <button
+            className="py-2 px-4 bg-red-500 text-white rounded"
+            onClick={onCancel}
+          >
+            {cancelButtonMessage}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+OkCancelModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  message: PropTypes.string.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  okButtonMessage: PropTypes.string,
+  cancelButtonMessage: PropTypes.string,
+};
+
+export default OkCancelModal;

--- a/frontend/src/components/ProductList.jsx
+++ b/frontend/src/components/ProductList.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useProductContext } from "../context/ProductContext";
 import Error from "./Error";
 import Loading from "./Loading";
@@ -6,6 +7,52 @@ const ProductList = () => {
   const { state, loading, error, setPage } = useProductContext();
 
   const { product_info, currentPage, totalPages, hasNext, hasPrevious } = state; //페이지네이션 및 데이터 필요한거 뽑아쓰기.
+
+  const [quantities, setQuantities] = useState({});
+  const [selectedProduct, setSelectedProduct] = useState(null); // 모달을 열기 위한 상태
+
+  const handleQuantityChange = (productId, change) => {
+    setQuantities((prev) => ({
+      ...prev,
+      [productId]: Math.max(1, (prev[productId] || 1) + change),
+    }));
+  };
+
+  const handleAddToCart = (product) => {
+    const { product_id, product_name, product_price } = product;
+    const count = quantities[product_id] || 1; // 기본값은 1
+
+    const newItem = {
+      id: product_id,
+      name: product_name,
+      price: product_price,
+      totalprice: product_price * count,
+      count: count,
+    };
+
+    const existingCart = JSON.parse(localStorage.getItem("cart")) || [];
+
+    const itemIndex = existingCart.findIndex((item) => item.id === product_id);
+    if (itemIndex > -1) {
+      existingCart[itemIndex].count += count;
+      existingCart[itemIndex].totalprice =
+        existingCart[itemIndex].price * existingCart[itemIndex].count;
+    } else {
+      existingCart.push(newItem);
+    }
+
+    alert("장바구니에 담겼습니다!");
+
+    localStorage.setItem("cart", JSON.stringify(existingCart));
+  };
+
+  const openModal = (product) => {
+    setSelectedProduct(product); // 클릭한 상품을 모달에 넘겨줌
+  };
+
+  const closeModal = () => {
+    setSelectedProduct(null); // 모달 닫기
+  };
 
   if (loading) return <Loading />;
   if (error) return <Error errorMessage={error} />;
@@ -16,11 +63,12 @@ const ProductList = () => {
 
       <div className="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 xl:gap-x-8">
         {product_info.map((product) => (
-          // todo: 상세 화면 어떻게 보여줄 것인지 생각 필요. 별도의 모달 창이 좋아보이긴함.
-          <a key={product.product_id} href={product.href} className="group">
+          <div key={product.product_id} className="group">
             <img
               src="https://i.imgur.com/HKOFQYa.jpeg"
+              alt={product.product_name}
               className="aspect-square w-full rounded-lg bg-gray-200 object-cover group-hover:opacity-75 xl:aspect-[7/8]"
+              onClick={() => openModal(product)} // 상품 클릭 시 모달 열기
             />
             <h3 className="mt-4 text-sm text-gray-700">
               {product.product_name}
@@ -28,7 +76,34 @@ const ProductList = () => {
             <p className="mt-1 text-lg font-medium text-gray-900">
               {product.product_price}원
             </p>
-          </a>
+
+            {/* 수량 선택 버튼 */}
+            <div className="mt-2 flex items-center">
+              <button
+                onClick={() => handleQuantityChange(product.product_id, -1)}
+                className="px-2 py-1 bg-gray-200 rounded-md"
+              >
+                -
+              </button>
+              <span className="mx-2">
+                {quantities[product.product_id] || 1}
+              </span>
+              <button
+                onClick={() => handleQuantityChange(product.product_id, 1)}
+                className="px-2 py-1 bg-gray-200 rounded-md"
+              >
+                +
+              </button>
+            </div>
+
+            {/* 카트에 담기 버튼 */}
+            <button
+              onClick={() => handleAddToCart(product)}
+              className="mt-4 py-2 px-6 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+            >
+              카트에 담기
+            </button>
+          </div>
         ))}
       </div>
 

--- a/frontend/src/context/CartContext.jsx
+++ b/frontend/src/context/CartContext.jsx
@@ -1,0 +1,49 @@
+import {
+  createContext,
+  useReducer,
+  useEffect,
+  useContext,
+  useRef,
+} from "react";
+import { cartReducer } from "./CartReducer";
+
+import PropTypes from "prop-types";
+
+// const initialCart = JSON.parse(localStorage.getItem("cart")) || [];
+
+export const CartContext = createContext();
+
+export const CartProvider = ({ children }) => {
+  const [cart, dispatch] = useReducer(cartReducer, []);
+  const isInitialRender = useRef(true); // 첫 렌더링 여부를 체크하는 ref
+
+  useEffect(() => {
+    console.log("초기로딩");
+    const storedCart = JSON.parse(localStorage.getItem("cart")) || [];
+    console.log(storedCart);
+    dispatch({ type: "SET_CART", payload: storedCart });
+  }, []);
+
+  useEffect(() => {
+    // 첫 번째 렌더링이 아닐 때만 로컬스토리지에 저장
+    if (isInitialRender.current) {
+      isInitialRender.current = false; // 첫 렌더링이 끝났으므로 `true`에서 `false`로 변경
+      return; // 첫 렌더링일 경우 로컬스토리지 업데이트하지 않음, 아직 state update 안된상태.
+    }
+
+    console.log("장바구니 내부 상태 변경!!");
+    localStorage.setItem("cart", JSON.stringify(cart));
+  }, [cart]);
+
+  return (
+    <CartContext.Provider value={{ cart, dispatch }}>
+      {children}
+    </CartContext.Provider>
+  );
+};
+
+CartProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useCartContext = () => useContext(CartContext);

--- a/frontend/src/context/CartReducer.js
+++ b/frontend/src/context/CartReducer.js
@@ -1,0 +1,43 @@
+export const cartReducer = (state, action) => {
+  switch (action.type) {
+    case "SET_CART":
+      return action.payload;
+    case "ADD_ITEM": {
+      const updatedCart = [...state, action.payload];
+      return updatedCart;
+    }
+    case "REMOVE_ITEM": {
+      const updatedCart = state.filter((item) => item.id !== action.payload);
+      return updatedCart;
+    }
+    case "CLEAR_CART": {
+      return [];
+    }
+    case "INCREASE_ITEM": {
+      const updatedCart = state.map((item) =>
+        item.id === action.payload
+          ? {
+              ...item,
+              count: item.count + 1,
+              totalprice: item.price * (item.count + 1),
+            }
+          : item
+      );
+      return updatedCart;
+    }
+    case "DECREASE_ITEM": {
+      const updatedCart = state.map((item) =>
+        item.id === action.payload && item.count > 1
+          ? {
+              ...item,
+              count: item.count - 1,
+              totalprice: item.price * (item.count - 1),
+            }
+          : item
+      );
+      return updatedCart;
+    }
+    default:
+      return state;
+  }
+};

--- a/frontend/src/pages/Cart.jsx
+++ b/frontend/src/pages/Cart.jsx
@@ -1,0 +1,17 @@
+import CartPage from "../components/CartPage";
+import CartPayment from "../components/CartPayment";
+
+import { CartProvider } from "../context/CartContext";
+
+const Cart = () => {
+  return (
+    <>
+      <CartProvider>
+        <CartPage />
+        <CartPayment />
+      </CartProvider>
+    </>
+  );
+};
+
+export default Cart;

--- a/frontend/src/pages/Main.jsx
+++ b/frontend/src/pages/Main.jsx
@@ -1,13 +1,14 @@
 import ProductList from "../components/ProductList";
 import ProductSearch from "../components/ProductSearch";
+import { ProductProvider } from "../context/ProductContext";
 
 const Main = () => {
   return (
-    <section>
-      <h1 className="text-center text-3xl mt2 mb-2">Grids & Circle</h1>
+    <ProductProvider>
+      <h1 className="text-center text-3xl mt-5 mb-2">Grids & Circle</h1>
       <ProductSearch />
       <ProductList />
-    </section>
+    </ProductProvider>
   );
 };
 


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

## 📝Part
- [ ] BE
- [x] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--#{Issue번호} + Enter
ex) #17
이슈와 PR 연결을 위해 사용합니다!-->

#34 
- 장바구니와 관련된 기능이 추가되었습니다.
  - 메인페이지 에서, 상품별로 장바구니에 담을 수 있는 기능이 적용되었습니다.
  - 장바구니에 담을 수량을 정할 수 있습니다.
  - 장바구니 페이지 에서도, 담긴 아이템들을 삭제/추가/감소 할 수 있습니다.
- 주문 생성 구현
  - 주문 생성  API 와 패치작업을 진행하였습니다.
---

  <br/>

## 📈이미지 첨부

- 메인페이지 -> 장바구니 담기
![image](https://github.com/user-attachments/assets/0a28b92a-d6f0-49b6-a5a3-dddf2e6cf4c0)

- 장바구니 UI
![image](https://github.com/user-attachments/assets/d163f552-9cff-40b2-bedf-9c86b1a611cc)

- 주문하기
![image](https://github.com/user-attachments/assets/05a62e73-9dcc-4ac8-9f1f-5a1ea5ef8934)
