### PR TITLE
[FEAT]: [BE] 관리자 주문 조회 기능 추가 등

### DIFF
--- a/backend/src/main/java/com/app/backend/domain/order/constant/OrderMessageConstant.java
+++ b/backend/src/main/java/com/app/backend/domain/order/constant/OrderMessageConstant.java
@@ -8,7 +8,8 @@ package com.app.backend.domain.order.constant;
  * Description :
  */
 public abstract class OrderMessageConstant {
-    public static final String ORDER_SAVE_SUCCESS   = "주문 성공";
-    public static final String ORDER_READ_SUCCESS   = "주문 조회 성공";
-    public static final String ORDER_CANCEL_SUCCESS = "주문 취소 성공";
+    public static final String ORDER_SAVE_SUCCESS      = "주문 성공";
+    public static final String ORDER_READ_SUCCESS      = "주문 조회 성공";
+    public static final String ORDER_LIST_READ_SUCCESS = "주문 목록 조회 성공";
+    public static final String ORDER_CANCEL_SUCCESS    = "주문 취소 성공";
 }

--- a/backend/src/main/java/com/app/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/app/backend/domain/order/repository/OrderRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 
+    Optional<Order> findByIdAndCustomer_Id(Long id, Long customerId);
+
     List<Order> findByCustomer_Id(Long id);
 
     List<Order> findByCustomer_IdAndStatus(Long id, OrderStatus status);

--- a/backend/src/main/java/com/app/backend/domain/user/controller/AdminController.java
+++ b/backend/src/main/java/com/app/backend/domain/user/controller/AdminController.java
@@ -1,0 +1,50 @@
+package com.app.backend.domain.user.controller;
+
+import com.app.backend.domain.order.constant.OrderMessageConstant;
+import com.app.backend.domain.order.dto.response.OrderResponse;
+import com.app.backend.domain.order.service.OrderService;
+import com.app.backend.domain.user.exception.UserException;
+import com.app.backend.global.error.exception.ErrorCode;
+import com.app.backend.global.rs.RsData;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * PackageName : com.app.backend.domain.user.controller
+ * FileName    : AdminController
+ * Author      : 강찬우
+ * Date        : 25. 1. 17.
+ * Description :
+ */
+@RestController
+@RequestMapping(value = "/api/v1/admin",
+                consumes = MediaType.APPLICATION_JSON_VALUE,
+                produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final OrderService orderService;
+
+    @GetMapping("/orders")
+    public RsData<List<OrderResponse>> getAllOrders(@AuthenticationPrincipal UserDetails userDetails) {
+        System.out.println("userDetails = " + userDetails);
+        if (!userDetails.getAuthorities().stream()
+                        .anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN")))   //관리자 권한 확인
+            throw new UserException(ErrorCode.HANDLE_ACCESS_DENIED);
+
+        List<OrderResponse> allOrders = orderService.getAllOrders();
+
+        return new RsData<>(true,
+                            String.valueOf(HttpStatus.OK.value()),
+                            OrderMessageConstant.ORDER_LIST_READ_SUCCESS,
+                            allOrders);
+    }
+
+}

--- a/backend/src/main/java/com/app/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/com/app/backend/global/error/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     //Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "O001", "주문 정보가 존재하지 않음"),
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, false, "O002", "잘못된 주문 상태"),
+    ORDER_BUYER_MISMATCH(HttpStatus.BAD_REQUEST, false, "O003", "주문 정보와 주문 회원 불일치"),
 
     //Payment
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, false, "E001", "결제 실패"),

--- a/backend/src/main/java/com/app/backend/global/initdata/BaseInitData.java
+++ b/backend/src/main/java/com/app/backend/global/initdata/BaseInitData.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ public class BaseInitData {
     private final UserRepository    userRepository;
     private final ProductRepository productRepository;
     private final OrderRepository   orderRepository;
+    private final PasswordEncoder   passwordEncoder;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
@@ -45,7 +47,7 @@ public class BaseInitData {
             String userStr = "user" + String.format("%0" + String.valueOf("size").length() + "d", i);
             User user = User.builder()
                             .email(userStr + "@mail.com")
-                            .password(userStr)
+                            .password(passwordEncoder.encode(userStr))
                             .name(userStr)
                             .address(userStr + " address")
                             .detailAddress(userStr + " detail address")

--- a/backend/src/main/java/com/app/backend/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/app/backend/global/security/SecurityConfig.java
@@ -22,23 +22,24 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(authorizeRequests ->
-                authorizeRequests
-                        .requestMatchers("/h2-console/**").permitAll()
-                        .requestMatchers("/api/*/signup").permitAll()
-                        .requestMatchers("/api/v1/users/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/*/products").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/*/products/*").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/*/products").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/*/products/*").permitAll()
-                        .requestMatchers(HttpMethod.PATCH, "/api/*/products").permitAll()
-                        .requestMatchers(HttpMethod.PATCH, "/api/*/products/*").permitAll()
-                        .requestMatchers(HttpMethod.DELETE, "/api/*/products").permitAll()
-                        .requestMatchers(HttpMethod.DELETE, "/api/*/products/*").permitAll()
-                )
-                .headers(headers ->
-                        headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
-                .csrf(csrf -> csrf.disable())
-                ;
+                                           authorizeRequests
+                                                   .requestMatchers("/h2-console/**").permitAll()
+                                                   .requestMatchers("/api/*/signup").permitAll()
+                                                   .requestMatchers("/api/v1/users/**").permitAll()
+                                                   .requestMatchers(HttpMethod.GET, "/api/*/products").permitAll()
+                                                   .requestMatchers(HttpMethod.GET, "/api/*/products/*").permitAll()
+                                                   .requestMatchers(HttpMethod.POST, "/api/*/products").permitAll()
+                                                   .requestMatchers(HttpMethod.POST, "/api/*/products/*").permitAll()
+                                                   .requestMatchers(HttpMethod.PATCH, "/api/*/products").permitAll()
+                                                   .requestMatchers(HttpMethod.PATCH, "/api/*/products/*").permitAll()
+                                                   .requestMatchers(HttpMethod.DELETE, "/api/*/products").permitAll()
+                                                   .requestMatchers(HttpMethod.DELETE, "/api/*/products/*").permitAll()
+                                                   .anyRequest().authenticated()
+            )
+            .headers(headers ->
+                             headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
+            .csrf(csrf -> csrf.disable())
+        ;
 
         return http.build();
     }

--- a/backend/src/test/java/com/app/backend/domain/order/controller/OrderControllerTest.java
+++ b/backend/src/test/java/com/app/backend/domain/order/controller/OrderControllerTest.java
@@ -21,6 +21,7 @@ import com.app.backend.domain.order.entity.Order;
 import com.app.backend.domain.order.repository.OrderRepository;
 import com.app.backend.domain.order.service.OrderService;
 import com.app.backend.domain.user.entity.User;
+import com.app.backend.global.annotation.CustomWithMockAdmin;
 import com.app.backend.global.error.exception.ErrorCode;
 import com.app.backend.global.rs.RsData;
 import com.app.backend.global.util.ReflectionUtil;
@@ -51,14 +52,8 @@ import org.springframework.web.method.annotation.HandlerMethodValidationExceptio
  * Description :
  */
 @ActiveProfiles("test")
-//@MockBean(JpaMetamodelMappingContext.class)
-//NOTE: @MockBean(JpaMetamodelMappingContext.class) -> Spring Boot 3.4.0 이후 사용되지 않음, 제거 예정
-//@EnableJpaAuditing을 Application에 적용 시 JPA metamodel 에러가 발생하며, 해결을 위해 @EnableJpaAuditing을 따로 Config 클래스로
-//분리 후 적용 필요
-//@Import(TestConfig.class)
-//@WebMvcTest(OrderController.class)
 @SpringBootTest
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 class OrderControllerTest {
 
     @MockitoBean
@@ -92,11 +87,12 @@ class OrderControllerTest {
         orderResponse = OrderResponse.of(order);
 
         when(orderService.saveOrder(anyLong(), any(OrderRequest.class))).thenReturn(1L);
-        when(orderService.getOrderById(anyLong())).thenReturn(orderResponse);
+        when(orderService.getOrderByIdAndUserId(anyLong(), anyLong())).thenReturn(orderResponse);
         doNothing().when(orderService).updateOrderStatus(anyLong(), anyString());
     }
 
     @Test
+    @CustomWithMockAdmin
     @DisplayName("saveOrder")
     void saveOrder() throws Exception {
         //Given
@@ -121,6 +117,7 @@ class OrderControllerTest {
     }
 
     @Test
+    @CustomWithMockAdmin
     @DisplayName("saveOrder, unknown product id")
     void saveOrder_unknownProductId() throws Exception {
         //Given
@@ -149,6 +146,7 @@ class OrderControllerTest {
     }
 
     @Test
+    @CustomWithMockAdmin
     @DisplayName("saveOrder, unknown amount")
     void saveOrder_unknownAmount() throws Exception {
         //Given
@@ -177,6 +175,7 @@ class OrderControllerTest {
     }
 
     @Test
+    @CustomWithMockAdmin
     @DisplayName("getOrderById")
     void getOrderById() throws Exception {
         //Given
@@ -199,6 +198,7 @@ class OrderControllerTest {
     }
 
     @Test
+    @CustomWithMockAdmin
     @DisplayName("getOrderById, unknown id")
     void getOrderById_unknownId() throws Exception {
         //Given
@@ -223,6 +223,7 @@ class OrderControllerTest {
     }
 
     @Test
+    @CustomWithMockAdmin
     @DisplayName("cancelOrder")
     void cancelOrder() throws Exception {
         //Given
@@ -243,6 +244,7 @@ class OrderControllerTest {
     }
 
     @Test
+    @CustomWithMockAdmin
     @DisplayName("cancelOrder, unknown id")
     void cancelOrder_unknownId() throws Exception {
         //Given
@@ -265,20 +267,5 @@ class OrderControllerTest {
                      .andExpect(content().json(objectMapper.writeValueAsString(rsData)))
                      .andDo(print());
     }
-
-//    @TestConfiguration
-//    static class TestConfig {
-//
-//        @Bean
-//        public Validator validator() {
-//            return new LocalValidatorFactoryBean();
-//        }
-//
-//        @Bean
-//        public MethodValidationPostProcessor methodValidationPostProcessor() {
-//            return new MethodValidationPostProcessor();
-//        }
-//
-//    }
 
 }

--- a/backend/src/test/java/com/app/backend/domain/order/repository/OrderRepositoryTest.java
+++ b/backend/src/test/java/com/app/backend/domain/order/repository/OrderRepositoryTest.java
@@ -74,6 +74,58 @@ class OrderRepositoryTest {
     }
 
     @ParameterizedTest
+    @CsvSource({"1, 1", "2, 2", "3, 3", "4, 4", "5, 5", "6, 1", "7, 2", "8, 3", "9, 4", "10, 5"})
+    @DisplayName("findByIdAndCustomer_Id")
+    void findByIdAndCustomer_Id(final long orderId, final long customerId) {
+        //Given
+
+        //When
+        Optional<Order> opOrder = orderRepository.findByIdAndCustomer_Id(orderId, customerId);
+
+        //Then
+        assertThat(opOrder).isNotEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1234567890, 1", "1234567890, 2", "1234567890, 3", "1234567890, 4", "1234567890, 5"})
+    @DisplayName("findByIdAndCustomer_Id, unknown order id")
+    void findByIdAndCustomer_Id_unknownOrderId(final long orderId, final long customerId) {
+        //Given
+
+        //When
+        Optional<Order> opOrder = orderRepository.findByIdAndCustomer_Id(orderId, customerId);
+
+        //Then
+        assertThat(opOrder).isEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1, 1234567890", "2, 1234567890", "3, 1234567890", "4, 1234567890", "5, 1234567890"})
+    @DisplayName("findByIdAndCustomer_Id, unknown customer id")
+    void findByIdAndCustomer_Id_unknownCustomerId(final long orderId, final long customerId) {
+        //Given
+
+        //When
+        Optional<Order> opOrder = orderRepository.findByIdAndCustomer_Id(orderId, customerId);
+
+        //Then
+        assertThat(opOrder).isEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1234567890, 1234567890", "987654321, 987654321"})
+    @DisplayName("findByIdAndCustomer_Id, unknown order id and customer id")
+    void findByIdAndCustomer_Id_unknownOrderIdAndCustomerId(final long orderId, final long customerId) {
+        //Given
+
+        //When
+        Optional<Order> opOrder = orderRepository.findByIdAndCustomer_Id(orderId, customerId);
+
+        //Then
+        assertThat(opOrder).isEmpty();
+    }
+
+    @ParameterizedTest
     @CsvSource({"1", "2", "3", "4", "5"})
     @DisplayName("findByCustomer_Id")
     void findByCustomer_Id(final long userId) {

--- a/backend/src/test/java/com/app/backend/domain/user/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/app/backend/domain/user/controller/AdminControllerTest.java
@@ -133,7 +133,7 @@ class AdminControllerTest {
                                                               .contentType(MediaType.APPLICATION_JSON_VALUE));
 
         //Then
-        resultActions.andExpect(status().isForbidden())
+        resultActions.andExpect(status().isBadRequest())
                      .andDo(print());
     }
 

--- a/backend/src/test/java/com/app/backend/domain/user/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/app/backend/domain/user/controller/AdminControllerTest.java
@@ -1,0 +1,142 @@
+package com.app.backend.domain.user.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.app.backend.domain.order.constant.OrderMessageConstant;
+import com.app.backend.domain.order.dto.response.OrderResponse;
+import com.app.backend.domain.order.entity.Order;
+import com.app.backend.domain.order.service.OrderService;
+import com.app.backend.domain.user.entity.User;
+import com.app.backend.domain.user.exception.UserException;
+import com.app.backend.global.error.exception.ErrorCode;
+import com.app.backend.global.rs.RsData;
+import com.app.backend.global.util.ReflectionUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+/**
+ * PackageName : com.app.backend.domain.user.controller
+ * FileName    : AdminControllerTest
+ * Author      : 강찬우
+ * Date        : 25. 1. 17.
+ * Description :
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminControllerTest {
+
+    @MockitoBean
+    private OrderService    orderService;
+    @Autowired
+    private AdminController adminController;
+    @Autowired
+    private MockMvc         mockMvc;
+    @Autowired
+    private ObjectMapper    objectMapper;
+
+    private OrderResponse orderResponse;
+
+    @BeforeEach
+    void beforeEach() {
+        User customer = User.builder()
+                            .email("user@mail.com")
+                            .password("user")
+                            .name("user")
+                            .address("user address")
+                            .detailAddress("user detail address")
+                            .phone("01000000000")
+                            .status("ACTIVATE")
+                            .role("ROLE_USER")
+                            .build();
+
+        Order order = Order.of(customer, "orderNumber", 1, BigDecimal.valueOf(10000.00),
+                               "%s %s".formatted(customer.getAddress(), customer.getDetailAddress()));
+        ReflectionUtil.setPrivateFieldValue(Order.class, order, "createdDate", LocalDateTime.now());
+
+        orderResponse = OrderResponse.of(order);
+
+        when(orderService.getAllOrders()).thenReturn(List.of(orderResponse));
+    }
+
+    @Test
+    @DisplayName("getAllOrders")
+    void getAllOrders() throws Exception {
+        //Given
+
+        //When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/admin/orders")
+                                                              .accept(MediaType.APPLICATION_JSON_VALUE)
+                                                              .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                              .with(user("admin").roles("ADMIN")));
+
+        //Then
+        RsData<Object> rsData = new RsData<>(true,
+                                             String.valueOf(HttpStatus.OK.value()),
+                                             OrderMessageConstant.ORDER_LIST_READ_SUCCESS,
+                                             List.of(orderResponse));
+
+        resultActions.andExpect(status().isOk())
+                     .andExpect(content().json(objectMapper.writeValueAsString(rsData)))
+                     .andDo(print());
+    }
+
+    @Test
+    @DisplayName("getAllOrders, unauthorized")
+    void getAllOrders_unauthorized() throws Exception {
+        //Given
+
+        //When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/admin/orders")
+                                                              .accept(MediaType.APPLICATION_JSON_VALUE)
+                                                              .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                              .with(user("admin").roles("USER")));
+
+        //Then
+        resultActions.andExpect(status().isForbidden())
+                     .andExpect(result -> {
+                         assertThat(result.getResolvedException() instanceof UserException).isTrue();
+                         final ErrorCode errorCode = ErrorCode.HANDLE_ACCESS_DENIED;
+                         assertThat(((UserException) result.getResolvedException()).getErrorCode())
+                                 .isEqualTo(errorCode);
+                         assertThat(result.getResolvedException().getMessage()).isEqualTo(errorCode.getMessage());
+                     })
+                     .andDo(print());
+    }
+
+    @Test
+    @DisplayName("getAllOrders, no authentication")
+    void getAllOrders_noAuthentication() throws Exception {
+        //Given
+
+        //When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/admin/orders")
+                                                              .accept(MediaType.APPLICATION_JSON_VALUE)
+                                                              .contentType(MediaType.APPLICATION_JSON_VALUE));
+
+        //Then
+        resultActions.andExpect(status().isForbidden())
+                     .andDo(print());
+    }
+
+}

--- a/backend/src/test/java/com/app/backend/domain/user/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/app/backend/domain/user/controller/AdminControllerTest.java
@@ -47,13 +47,11 @@ import org.springframework.test.web.servlet.ResultActions;
 class AdminControllerTest {
 
     @MockitoBean
-    private OrderService    orderService;
+    private OrderService orderService;
     @Autowired
-    private AdminController adminController;
+    private MockMvc      mockMvc;
     @Autowired
-    private MockMvc         mockMvc;
-    @Autowired
-    private ObjectMapper    objectMapper;
+    private ObjectMapper objectMapper;
 
     private OrderResponse orderResponse;
 
@@ -110,7 +108,7 @@ class AdminControllerTest {
         ResultActions resultActions = mockMvc.perform(get("/api/v1/admin/orders")
                                                               .accept(MediaType.APPLICATION_JSON_VALUE)
                                                               .contentType(MediaType.APPLICATION_JSON_VALUE)
-                                                              .with(user("admin").roles("USER")));
+                                                              .with(user("user").roles("USER")));
 
         //Then
         resultActions.andExpect(status().isForbidden())


### PR DESCRIPTION
- 관리자 권한 대상 접근 가능 URL 구현
  · 모든 주문 목록 조회(/api/v1/admin/orders) 추가
- OrderMessageConstant 메시지 1개 추가
  · "주문 목록 조회 성공" 추가<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [x] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--#{Issue번호} + Enter
ex) #17
이슈와 PR 연결을 위해 사용합니다!-->

- 관리자의 모든 주문 목록 조회 구현
	- 테스트 코드 작성
- 시큐리티 적용에 따른 인증 필요 API 수정
	- 주문(Order) 저장, 조회, 취소에 적용
	- 주문 관련 에러 코드 1개 추가
	- 관련 테스트 코드 추가 및 수정(OrderRepository, OrderService, OrderController)
- 더미 데이터 생성 클래스(BaseInitData) 수정
	- 회원 엔티티 생성 시 비밀번호 암호화 적용

  <br/>

## 📈이미지 첨부
