### PR TITLE
[FEAT] : [FE] 로그인 및 로그아웃 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,9 @@ import { Routes, Route } from "react-router-dom";
 import Signup from "./pages/Signup";
 import Main from "./pages/Main";
 import Cart from "./pages/Cart";
+import Login from "./pages/Login";
+
+import ProtectedRoute from "./pages/PrivateRoute";
 
 function App() {
   return (
@@ -10,12 +13,41 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<Main />} />
-          <Route path="/login" element={<div>로그인 페이지 컴포넌트</div>} />
+          <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
-          <Route path="/mypage" element={<div>마이페이지 컴포넌트</div>} />
-          <Route path="/admin" element={<div>상품 등록 컴포넌트</div>} />
-          <Route path="/logout" element={<div>로그아웃 컴포넌트</div>} />
-          <Route path="/cart" element={<Cart />} />
+          {/* Protected Routes */}
+          <Route
+            path="/mypage"
+            element={
+              <ProtectedRoute>
+                <div>마이페이지 컴포넌트</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin"
+            element={
+              <ProtectedRoute>
+                <div>관리자 컴포넌트</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/logout"
+            element={
+              <ProtectedRoute>
+                <div>로그아웃 컴포넌트</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/cart"
+            element={
+              <ProtectedRoute>
+                <Cart />
+              </ProtectedRoute>
+            }
+          />
         </Routes>
       </Layout>
     </>

--- a/frontend/src/components/CartPayment.jsx
+++ b/frontend/src/components/CartPayment.jsx
@@ -36,7 +36,7 @@ const CartPayment = () => {
     };
 
     try {
-      const response = await request("/orders", "POST", productData);
+      const response = await request("/orders", "POST", productData, {}, true);
       alert(response.message);
       navigate("/mypage");
     } catch (err) {

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,8 +1,33 @@
 import { Link } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
-// TODO: 현재 로그인 상태에 맞춰서 동적으로, 리스트 버튼들 변화하도록 설정 필요.
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import useApi from "../hooks/useApi";
+import OkCancelModal from "./OkCancelModal"; // OkCancelModal 컴포넌트 가져오기
 
 const Navbar = () => {
+  const { isAuthenticated, logout } = useAuth();
+  const { request } = useApi();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    try {
+      await request("/logout", "POST", {}, {}, true);
+      logout();
+      setIsModalOpen(false);
+      navigate("/");
+    } catch (error) {
+      console.error("로그아웃 실패:", error);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsModalOpen(false);
+  };
+
   return (
     <header className="bg-light border-b border-gray-500 container mx-auto mt-2 mb-2 px-2 sm:px-6 lg:px-8">
       <nav className="relative flex items-center justify-between h-16">
@@ -12,44 +37,53 @@ const Navbar = () => {
         </Link>
         {/* 버튼 동적 리스트 */}
         <ul className="flex items-center space-x-4">
-          <li>
-            <Link
-              to="/login"
-              className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
-            >
-              로그인
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="/signup"
-              className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
-            >
-              회원가입
-            </Link>
-          </li>
+          {!isAuthenticated && (
+            <>
+              <li>
+                <Link
+                  to="/login"
+                  className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
+                >
+                  로그인
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/signup"
+                  className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
+                >
+                  회원가입
+                </Link>
+              </li>
+            </>
+          )}
+
+          {isAuthenticated && (
+            <>
+              <li>
+                <button
+                  onClick={() => setIsModalOpen(true)} // 모달 열기
+                  className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
+                >
+                  로그아웃
+                </button>
+              </li>
+              <li>
+                <Link
+                  to="/admin"
+                  className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
+                >
+                  관리자 페이지
+                </Link>
+              </li>
+            </>
+          )}
           <li>
             <Link
               to="/mypage"
               className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
             >
               마이페이지
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="/logout"
-              className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
-            >
-              로그아웃
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="/admin"
-              className="text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm font-medium"
-            >
-              상품 등록
             </Link>
           </li>
           <li>
@@ -62,6 +96,16 @@ const Navbar = () => {
           </li>
         </ul>
       </nav>
+
+      {/* 로그아웃 확인 모달 */}
+      <OkCancelModal
+        isOpen={isModalOpen}
+        message="로그아웃 하시겠습니까?"
+        onConfirm={handleLogout} // 로그아웃 확정 시 실행
+        onCancel={handleCancel} // 취소 시 실행
+        okButtonMessage="확인"
+        cancelButtonMessage="취소"
+      />
     </header>
   );
 };

--- a/frontend/src/components/OkCancelModal.jsx
+++ b/frontend/src/components/OkCancelModal.jsx
@@ -11,7 +11,7 @@ const OkCancelModal = ({
   if (!isOpen) return null; // 모달이 열려있지 않으면 아무 것도 렌더링하지 않음
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-white p-6 rounded-lg shadow-lg">
         <p>{message}</p>
         <div className="mt-4">

--- a/frontend/src/components/ProductDetailModal.jsx
+++ b/frontend/src/components/ProductDetailModal.jsx
@@ -24,7 +24,13 @@ const ProductDetailModal = ({ productId, onClose }) => {
   useEffect(() => {
     const fetchProductDetails = async () => {
       try {
-        const response = await request(`/products/${productId}`);
+        const response = await request(
+          `/products/${productId}`,
+          "GET",
+          {},
+          {},
+          false
+        );
         console.log(response.data);
         setProductInfo(response.data);
         setError(null);

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState, useEffect } from "react";
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    // 초기 로컬스토리지 확인
+    const token = localStorage.getItem("Authorization");
+    setIsAuthenticated(!!token);
+
+    // storage 이벤트 핸들러
+    const handleStorageChange = () => {
+      const updatedToken = localStorage.getItem("Authorization");
+      setIsAuthenticated(!!updatedToken);
+    };
+
+    // storage 이벤트 리스너 추가
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+      window.removeEventListener("storage", handleStorageChange); // 리스너 정리
+    };
+  }, []);
+
+  const login = () => {
+    setIsAuthenticated(true);
+  };
+
+  const logout = () => {
+    localStorage.removeItem("Authorization");
+    setIsAuthenticated(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useState, useEffect } from "react";
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(true);
 
   useEffect(() => {
     // 초기 로컬스토리지 확인

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -13,15 +13,32 @@ const useApi = () => {
     baseURL,
     headers: {
       "Content-Type": "application/json",
+      Authorization: "",
     },
+    withCredentials: true,
     validateStatus: (status) => {
       return status >= 200 && status < 500;
     },
   });
 
-  const request = async (endpoint, method = "GET", data = {}, params = {}) => {
+  const request = async (
+    endpoint,
+    method = "GET",
+    data = {},
+    params = {},
+    includeAuth
+  ) => {
     setLoading(true);
     setError(null);
+
+    if (includeAuth) {
+      const token = localStorage.getItem("Authorization") || "";
+      if (token) {
+        apiClient.defaults.headers["Authorization"] = token;
+      }
+    } else {
+      delete apiClient.defaults.headers["Authorization"];
+    }
 
     try {
       const response = await apiClient.request({
@@ -30,6 +47,12 @@ const useApi = () => {
         data,
         params,
       });
+
+      const newAuthToken = response.headers["authorization"];
+      console.log(`AuthToken : ${newAuthToken}`);
+      if (newAuthToken) {
+        localStorage.setItem("Authorization", newAuthToken);
+      }
 
       if (!response.data.isSuccess) {
         throw new Error(response.data.message || "Unknown error");

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -48,7 +48,7 @@ const useApi = () => {
         params,
       });
 
-      const newAuthToken = response.headers["authorization"];
+      const newAuthToken = response.headers["Authorization"];
       console.log(`AuthToken : ${newAuthToken}`);
       if (newAuthToken) {
         localStorage.setItem("Authorization", newAuthToken);

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -48,7 +48,7 @@ const useApi = () => {
         params,
       });
 
-      const newAuthToken = response.headers["Authorization"];
+      const newAuthToken = response.headers["authorization"];
       console.log(`AuthToken : ${newAuthToken}`);
       if (newAuthToken) {
         localStorage.setItem("Authorization", newAuthToken);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "./context/AuthContext";
 
 import "./index.css";
 
@@ -8,8 +9,10 @@ import App from "./App.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AuthProvider>
   </StrictMode>
 );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import useApi from "../hooks/useApi";
+import { useAuth } from "../context/AuthContext";
+
+const Login = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const { request, loading } = useApi();
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    try {
+      const response = await request(
+        "/login",
+        "POST",
+        { email, password },
+        {},
+        false
+      );
+      console.log(response);
+      alert(response.message);
+      login();
+      navigate("/mypage");
+    } catch (err) {
+      console.error("로그인 실패:", err);
+      alert(err);
+    }
+  };
+
+  return (
+    <main className="flex flex-col justify-center px-6 py-12 lg:px-8">
+      {/* 로고와 제목 */}
+      <header className="text-center">
+        <img
+          alt="Company Logo - Login"
+          src="https://tailwindui.com/plus/img/logos/mark.svg?color=indigo&shade=600"
+          className="mx-auto h-10 w-auto"
+        />
+        <h2 className="mt-6 text-2xl font-bold tracking-tight text-gray-900">
+          로 그 인
+        </h2>
+      </header>
+
+      {/* 로그인 폼 */}
+      <form
+        onSubmit={handleSubmit}
+        className="mt-10 mx-auto w-full max-w-sm space-y-6"
+      >
+        {/* 이메일 입력 */}
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-900">
+            Email address
+          </span>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            autoComplete="email"
+            className="mt-2 block w-full rounded-md bg-white px-3 py-2 text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline-indigo-600"
+          />
+        </label>
+
+        {/* 비밀번호 입력 */}
+        <label className="block">
+          <span className="flex justify-between text-sm font-medium text-gray-900">
+            Password
+            <a
+              href="#"
+              className="font-semibold text-indigo-600 hover:text-indigo-500"
+            >
+              비밀번호 분실 하셨나요?
+            </a>
+          </span>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            autoComplete="current-password"
+            className="mt-2 block w-full rounded-md bg-white px-3 py-2 text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline-indigo-600"
+          />
+        </label>
+
+        {/* 로그인 버튼 */}
+        <button
+          type="submit"
+          className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-indigo-600"
+          disabled={loading}
+        >
+          {loading ? "처리 중..." : "로 그 인"}
+        </button>
+      </form>
+    </main>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/PrivateRoute.jsx
+++ b/frontend/src/pages/PrivateRoute.jsx
@@ -1,0 +1,15 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+const PrivateRoute = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) {
+    alert("로그인이 필요합니다.");
+    return <Navigate to="/login" />;
+  }
+
+  return children;
+};
+
+export default PrivateRoute;

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,4 +1,3 @@
-// Signup.js
 import { useNavigate } from "react-router-dom";
 
 import useApi from "../hooks/useApi";
@@ -11,7 +10,7 @@ const Signup = () => {
   const { request, loading } = useApi();
 
   const validationRules = {
-    username: [
+    name: [
       (value) => !value && "사용자 이름을 입력해주세요.",
       (value) =>
         value.length < 1 ||
@@ -35,7 +34,7 @@ const Signup = () => {
         "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
     ],
     address: [(value) => !value && "주소를 입력해주세요."],
-    address_detail: [(value) => !value && "상세 주소를 입력해주세요."],
+    detailAddress: [(value) => !value && "상세 주소를 입력해주세요."],
     phone: [
       (value) => !value && "전화번호를 입력해주세요.",
       (value) =>
@@ -46,12 +45,12 @@ const Signup = () => {
 
   const { formData, errors, handleChange, validate } = useFormValidation(
     {
-      username: "",
+      name: "",
       email: "",
       password: "",
       confirmPassword: "",
       address: "",
-      address_detail: "",
+      detailAddress: "",
       phone: "",
     },
     validationRules
@@ -63,8 +62,19 @@ const Signup = () => {
     const validationErrors = validate();
     if (Object.keys(validationErrors).length > 0) return;
 
+    const requestData = {
+      email: formData.email,
+      password: formData.password,
+      name: formData.name,
+      address: formData.address,
+      detailAddress: formData.detailAddress,
+      phone: formData.phone,
+    };
+
+    console.log(requestData);
+
     try {
-      const response = await request("/signup", "POST", formData);
+      const response = await request("/signup", "POST", formData, {}, false);
       alert(response.message);
       navigate("/login");
     } catch (err) {
@@ -80,12 +90,12 @@ const Signup = () => {
         </h1>
         <form className="space-y-4" onSubmit={handleSubmit}>
           <InputField
-            id="username"
-            name="username"
+            id="name"
+            name="name"
             label="사용자 이름"
-            value={formData.username}
+            value={formData.name}
             onChange={handleChange}
-            error={errors.username}
+            error={errors.name}
             placeholder="사용자 이름을 입력하세요"
           />
           <InputField
@@ -127,12 +137,12 @@ const Signup = () => {
             placeholder="주소를 입력하세요"
           />
           <InputField
-            id="address_detail"
-            name="address_detail"
+            id="detailAddress"
+            name="detailAddress"
             label="상세 주소"
-            value={formData.address_detail}
+            value={formData.detailAddress}
             onChange={handleChange}
-            error={errors.address_detail}
+            error={errors.detailAddress}
             placeholder="상세 주소를 입력하세요"
           />
           <InputField


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

## 📝Part
- [ ] BE
- [x] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--#{Issue번호} + Enter
ex) #17
이슈와 PR 연결을 위해 사용합니다!-->

### 변경 내용이 조금 많습니다

#57 
- 로그인 기능 구현이 되었습니다.
  - 별도의 로그인 페이지를 구현하였습니다.

- 로그아웃 기능이 구현 되었습니다.

- 로그인 상태에 따라, 접근 가능한 페이지를 구별하였습니다.
  - 마이페이지(+하위),  관리자페이지(+하위), 로그아웃 기능, 장바구니 페이지 (+하위) 는 로그인 필요
  - 만약, 로그인 하지 않은 상태에서 해당 페이지에 접근 시, 로그인 페이지로 유도됩니다.

- 로그인 상태에 따라, 화면에 표시될 네비게이션 버튼이 변경되었습니다.
  - 항상 보이는 버튼 : [홈, 마이페이지, 장바구니]
  - 로그인 시 보이는 버튼 : [로그아웃, 관리자 페이지, 마이페이지]
  - 로그아웃 시 보이는 버튼 : [로그인 회원가입]

---
- 내부적으로, useApi 커스텀 훅의 작동 방법을 상세히 변경하였습니다.
  - params, 인증 사용 여부를 props 로 전달받도록 수정하였습니다.
  - 그에따라, 유동적으로 header 에 토큰을 자동 추가하도록 수정하였습니다.
  - 추가적으로, refresh 로 인해, 재발급 되었을 때, 기존의 access Token을 자동으로 바꾸도록 변경하였습니다.


  <br/>

## 📈이미지 첨부

- 기본 로그인 페이지
![image](https://github.com/user-attachments/assets/3411fc6f-2951-4e0b-ac40-ab0335f3c6cf)

- 로그아웃 시, 생성될 모달
![image](https://github.com/user-attachments/assets/e294155f-24f8-483f-9bcb-3a3c0e8122f2)

- 로그인이 필요한 페이지 접근 시,
![image](https://github.com/user-attachments/assets/fa428092-91fb-40e6-b2fd-d9553160e1d2)

- 리프래쉬로 자동 재발급 적용 확인
![image](https://github.com/user-attachments/assets/73e5480f-7c32-4431-95fd-130fe4ed39dd)
![image](https://github.com/user-attachments/assets/4604bc04-52d9-49cf-b6b8-eff6013b625b)

